### PR TITLE
Fix Makefile issue to build shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Ref: https://github.com/github/gitignore/blob/master/C%2B%2B.gitignore
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/src/libsqlpp/Makefile
+++ b/src/libsqlpp/Makefile
@@ -12,7 +12,7 @@ LD = g++
 WINDRES = windres
 
 INC = 
-CFLAGS = -Wall -fexceptions
+CFLAGS = -Wall -fexceptions -fPIC
 RESINC = 
 LIBDIR = 
 LIB = 


### PR DESCRIPTION
Missing -fPIC option to g++
Message from g++: "recompile with -fPIC"

Command and output before fix:
$ make
test -d bin/Debug || mkdir -p bin/Debug
test -d obj/Debug || mkdir -p obj/Debug
test -d obj/Debug/src || mkdir -p obj/Debug/src
g++ -Wall -fexceptions -g  -Iinclude -c main.cpp -o obj/Debug/main.o
g++ -Wall -fexceptions -g  -Iinclude -c src/DBColumn.cpp -o obj/Debug/src/DBColumn.o
g++ -Wall -fexceptions -g  -Iinclude -c src/DBObject.cpp -o obj/Debug/src/DBObject.o
g++ -shared  obj/Debug/main.o obj/Debug/src/DBColumn.o obj/Debug/src/DBObject.o  -o bin/Debug/sqlpp.so
/usr/bin/ld: obj/Debug/src/DBColumn.o: relocation R_X86_64_32S against `_ZTV8DBColumn' can not be used when making a shared object; recompile with -fPIC
obj/Debug/src/DBColumn.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
Makefile:62: recipe for target 'out_debug' failed
make: *** [out_debug] Error 1